### PR TITLE
chore: revamp actions and scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules
 .env
 .env.*
 !.env.example
+
+# storybook
+storybook-static

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
 	"main": "./index.js",
 	"scripts": {
 		"dev": "vite dev",
-		"build": "svelte-kit sync && svelte-package",
-		"package": "svelte-kit package",
+		"build": "svelte-kit sync && vite build",
+		"package": "svelte-kit sync && svelte-kit package",
 		"preview": "svelte-kit preview",
 		"create:story": "hygen create storybook",
 		"create:component": "hygen create component",

--- a/src/app.html
+++ b/src/app.html
@@ -5,6 +5,7 @@
 		<meta name="description" content="" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Chakra UI Svelte</title>
 		%sveltekit.head%
 	</head>
 	<body>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { ChakraProvider } from '$lib/components';
-	import Footer from '../docs/layout/Footer.svelte';
+	import Footer from '$docs/layout/Footer.svelte';
 </script>
 
 <ChakraProvider>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,11 @@
 {
-	"extends": "./.svelte-kit/tsconfig.json"
+	"extends": "./.svelte-kit/tsconfig.json",
+	"compilerOptions": {
+		"paths": {
+			"$lib": ["src/lib"],
+			"$lib/*": ["src/lib/*"],
+			"$docs": ["src/docs"],
+			"$docs/*": ["src/docs/*"]
+		}
+	}
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ const config: UserConfig = {
 	resolve: {
 		alias: {
 			$lib: resolve('./src/lib'),
-			$components: resolve('./src/components')
+			$docs: resolve('./src/docs')
 		}
 	}
 };


### PR DESCRIPTION
This PR does nothing fancy. I'm in the midst of migrating to histoire for documentation as it's more easy to set up for svelte projects and the current storybook set up seems to have been broken.

This PR is a prelude to this. It moves the landing page (https://chakra-svelte.vercel.app) components into a specialized dir and fixes build commands