### PR TITLE
fix: icon event and styles bubbling

### DIFF
--- a/src/docs/components/SocialButton.svelte
+++ b/src/docs/components/SocialButton.svelte
@@ -8,7 +8,7 @@
 <Link {href} {target} {rel}>
 	<Button>
 		<VisuallyHidden>{label}</VisuallyHidden>
-		<Icon as={SocialIcon} width="10px" />
+		<Icon as={SocialIcon} wrap="div" />
 		<slot />
 	</Button>
 </Link>

--- a/src/lib/components/basic/Box.svelte
+++ b/src/lib/components/basic/Box.svelte
@@ -1,36 +1,31 @@
-<script>
-	import { current_component, onMount } from 'svelte/internal';
-	import { eventsForward, chakra, colorMode, pick, omit } from '$lib';
+<script lang="ts">
+	import { current_component } from 'svelte/internal';
+	import { eventsForward, chakra, createStyle, omit } from '$lib';
 
 	export let events = eventsForward(current_component);
-	export let as = 'div';
-	export let colormode = $colorMode;
+	export let as: any = 'div';
 	export const apply = 'Box';
+	export let wrap: boolean | string = false;
 	export let props = {};
 	export let sx = {};
 
-	let bound;
-	onMount(() => {
-		if (bound) {
-			events(bound);
-		}
-		const el = document.createElement(typeof as === 'string' ? as : 'div');
-		const baseProps = pick($$props, Object.keys(el.__proto__));
-		props = {
-			colormode,
-			...omit(baseProps, ['toString']),
-			...props,
-			...sx
-		};
-	});
+	const styles = createStyle({ sx, ...props });
 </script>
 
 {#if typeof as === 'string'}
-	<svelte:element this={as} use:chakra={$$props} use:events>
+	<svelte:element this={as} use:chakra={$$props} use:events {...props}>
 		<slot />
 	</svelte:element>
 {:else if typeof as !== 'string'}
-	<svelte:component this={as} {colormode} bind:this={bound} on:click>
-		<slot />
-	</svelte:component>
+	{#if wrap}
+		<div class={styles} use:events {...props}>
+			<svelte:component this={as}>
+				<slot />
+			</svelte:component>
+		</div>
+	{:else}
+		<svelte:component this={as} class={styles} {...props}>
+			<slot />
+		</svelte:component>
+	{/if}
 {/if}

--- a/src/lib/components/basic/Icon.svelte
+++ b/src/lib/components/basic/Icon.svelte
@@ -5,40 +5,8 @@
 
 	const events = eventsForward(current_component);
 	export let as = 'svg';
-	export let viewBox = '0 0 24 24';
-	export let fill = 'none';
-	export let stroke = 'currentColor';
-	export let strokeWidth = '2';
-	export let strokeLinecap = 'round';
-	export let strokeLinejoin = 'round';
-
-	export let sx = {
-		display: 'inline-block',
-		lineHeight: '1em',
-		flexShrink: 0,
-		color: 'red'
-	};
 </script>
 
-{#if typeof as === 'string'}
-	<Box
-		{as}
-		{events}
-		props={{
-			viewBox,
-			ariaHidden: true,
-			fill,
-			stroke,
-			strokeWidth,
-			strokeLinecap,
-			strokeLinejoin,
-			width: '0.5em',
-			height: '0.5em'
-		}}
-		{...$$props}
-	>
-		<slot />
-	</Box>
-{:else if typeof as !== 'string'}
-	<Box {as} {events} {sx} fill="red" {...$$props} />
-{/if}
+<Box {as} {events} sx={{ width: '20px' }} {...$$props}>
+	<slot />
+</Box>

--- a/src/lib/core/styled.ts
+++ b/src/lib/core/styled.ts
@@ -2,20 +2,16 @@ import { css, toCSSVar } from '@chakra-ui/styled-system';
 import { theme } from '$lib/theme';
 import { system, cx } from './emotion';
 
-export function chakra<T>(node: HTMLElement, props: T) {
-	function update(props) {
-		const className = createClass(props, props.class);
-		node.className = className;
-	}
-
-	update(props);
-
-	return { update };
-}
-
-export function createClass(props, ...classList: string[]) {
-	const themeVars = toCSSVar(theme);
-	const componentStyles = {
+/**
+ * A Chakra UI Svelte component can be created to inherit styles using the `apply` prop.
+ * This util allows easy generation of styles based on the value of the `apply` prop.
+ * This styles can then be converted into classes later on
+ *
+ * @param props
+ * @returns
+ */
+export function extractComponentStyles(props) {
+	let componentStyles = {
 		colorScheme: props.colorScheme
 	};
 	const component = theme?.components[props.apply || props.as];
@@ -26,17 +22,59 @@ export function createClass(props, ...classList: string[]) {
 		if (!componentStyles.colorScheme) {
 			componentStyles.colorScheme = defaultProps?.colorScheme;
 		}
-		Object.assign(componentStyles, {
+		componentStyles = {
+			...componentStyles,
 			...baseStyle,
 			...sizeStyle,
 			...variants?.[variant](componentStyles)
-		});
+		};
 	}
+	return componentStyles;
+}
+
+/**
+ * Creates and return a class based on a components props
+ *
+ * @param props
+ * @returns
+ */
+export function createStyle(props) {
+	console.log('sx', props);
+	const themeVars = toCSSVar(theme);
+	const componentCSS = css(props)(themeVars);
+	const sxCss = css(props.sx)(themeVars);
+	return cx(system(componentCSS), system(sxCss), props.class);
+}
+
+/**
+ * Creates and return a class based on a components props and it's applied style
+ *
+ * @param props
+ * @returns
+ */
+export function createClass(props, ...classList: string[]) {
+	const themeVars = toCSSVar(theme);
+	const componentStyles = extractComponentStyles(props);
 	const baseCSS = css(props)(themeVars);
 	const sxCss = css(props.sx || {})(themeVars);
 	const componentCSS = css(componentStyles)(themeVars);
-	const baseName = system(baseCSS);
-	const sxName = system(sxCss);
-	const componentClassName = system(componentCSS);
-	return cx(componentClassName, baseName, sxName, ...classList);
+	return cx(system(componentCSS), system(baseCSS), system(sxCss), ...classList);
+}
+
+/**
+ * Base action to style nodes
+ *
+ * @param node
+ * @param props
+ * @returns
+ */
+export function chakra<T>(node: HTMLElement, props: T) {
+	function update(props) {
+		const className = createClass(props, props.class);
+		node.className = className;
+	}
+
+	update(props);
+
+	return { update };
 }

--- a/src/lib/index.d.ts
+++ b/src/lib/index.d.ts
@@ -61,7 +61,8 @@ type DimensionProps = {
 };
 
 type ChakraComponentProps = DimensionProps & {
-	as?: PropValue<keyof HTMLElementTagNameMap> | SvelteComponentTyped;
+	as?: keyof HTMLElementTagNameMap | SvelteComponentTyped;
+	wrap: boolean | keyof HTMLElementTagNameMap;
 	size?: PropSizes;
 	fontSize?: PropSizes;
 	fontFamily?: PropValue<string>;


### PR DESCRIPTION
Currently, It's really hard to bubble events and pass styles to `svelte:component`.
This is because, `use` directive works only for elements and as such, bubbling events wouldn't work.
Passing styles around too is difficult since `use:chakra` is not allowed either. For many months, I thought on how this can be achieved. And after so long, I got it finally.

This PR adds a `wrap` prop which allows `svelte:component` to be wrapped with an element of choice. This element would in turn receive all styles and events.
It also adds one more thing. It creates styles and passes its as a class to the underlying component.
This way, it's easier to simply decide not to use `wrap`