### PR TITLE
fix: disable $lib imports

### DIFF
--- a/src/lib/components/basic/Box.svelte
+++ b/src/lib/components/basic/Box.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { current_component } from 'svelte/internal';
-	import { eventsForward, chakra, createStyle, omit } from '$lib';
+	import { eventsForward, createStyle, chakra } from '$lib/core';
 
 	export let events = eventsForward(current_component);
 	export let as: any = 'div';

--- a/src/lib/components/providers/ChakraProvider.svelte
+++ b/src/lib/components/providers/ChakraProvider.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { toCSSVar } from '@chakra-ui/styled-system';
-	import { theme as baseTheme, themeStore, injectGlobal } from '$lib';
+	import { injectGlobal } from '$lib/core';
+	import { theme as baseTheme, themeStore } from '$lib/theme';
 
 	export let theme = baseTheme;
 	export let isMounted = false;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
 		"paths": {
-			"$lib": ["./src/lib"],
 			"$lib/*": ["./src/lib/*"],
 			"$docs": ["./src/docs"],
 			"$docs/*": ["./src/docs/*"]


### PR DESCRIPTION
There seems to be a change in svelte-package which I must have missed over the months. Apparently, imports from `$lib` only fail to resolve and this is making apps built with this library to keep crashing.

This PR fixes this.