### PR TITLE
feat: pass all element native props

### DIFF
--- a/src/lib/components/basic/Box.svelte
+++ b/src/lib/components/basic/Box.svelte
@@ -10,21 +10,38 @@
 	export let sx = {};
 
 	const styles = createStyle({ sx, ...props });
+    /**
+     * Ideally, we should be able to use the `props` attribute to forward all props to the underlying element.
+     * However, this would be really troublesome to maintain as we would have to manually add all props to the `props` attribute.
+     * Instead, we use the `as` attribute to determine the underlying element and forward all props to it.
+     * 
+     * If the `as` attribute is a string, we use the `svelte:element` component to forward all props to the underlying element.
+     * In future versions of Svelte, we can use the `use:props` directive to forward all props to the underlying element.
+     * The `props` attribute may also become deprecated.
+    */
+	const attributes = {
+		...(typeof as === 'string'
+			? Object.keys(document.createElement(as).__proto__).reduce((acc, name) => {
+					return { ...acc, [name]: $$props[name] };
+			  }, {})
+			: {}),
+		...props
+	};
 </script>
 
 {#if typeof as === 'string'}
-	<svelte:element this={as} use:chakra={$$props} use:events {...props}>
+	<svelte:element this={as} use:chakra={$$props} use:events {...attributes}>
 		<slot />
 	</svelte:element>
 {:else if typeof as !== 'string'}
 	{#if wrap}
-		<div class={styles} use:events {...props}>
+		<div class={styles} use:events {...attributes}>
 			<svelte:component this={as}>
 				<slot />
 			</svelte:component>
 		</div>
 	{:else}
-		<svelte:component this={as} class={styles} {...props}>
+		<svelte:component this={as} class={styles} {...attributes}>
 			<slot />
 		</svelte:component>
 	{/if}

--- a/src/lib/components/basic/Box.svelte
+++ b/src/lib/components/basic/Box.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { current_component } from 'svelte/internal';
-	import { eventsForward, createStyle, chakra } from '$lib/core';
+	import { eventsForward, createStyle, chakra, forwardAttributes } from '$lib/core';
 
 	export let events = eventsForward(current_component);
 	export let as: any = 'div';
@@ -10,38 +10,28 @@
 	export let sx = {};
 
 	const styles = createStyle({ sx, ...props });
-    /**
-     * Ideally, we should be able to use the `props` attribute to forward all props to the underlying element.
-     * However, this would be really troublesome to maintain as we would have to manually add all props to the `props` attribute.
-     * Instead, we use the `as` attribute to determine the underlying element and forward all props to it.
-     * 
-     * If the `as` attribute is a string, we use the `svelte:element` component to forward all props to the underlying element.
-     * In future versions of Svelte, we can use the `use:props` directive to forward all props to the underlying element.
-     * The `props` attribute may also become deprecated.
-    */
-	const attributes = {
-		...(typeof as === 'string'
-			? Object.keys(document.createElement(as).__proto__).reduce((acc, name) => {
-					return { ...acc, [name]: $$props[name] };
-			  }, {})
-			: {}),
-		...props
-	};
+	// this provides a fine grained control over the component's props
+	const attributes = forwardAttributes(as, $$props);
 </script>
 
 {#if typeof as === 'string'}
-	<svelte:element this={as} use:chakra={$$props} use:events {...attributes}>
+	<svelte:element this={as} use:chakra={$$props} use:events use:attributes>
 		<slot />
 	</svelte:element>
 {:else if typeof as !== 'string'}
 	{#if wrap}
-		<div class={styles} use:events {...attributes}>
+		<div class={styles} use:events use:attributes>
 			<svelte:component this={as}>
 				<slot />
 			</svelte:component>
 		</div>
 	{:else}
-		<svelte:component this={as} class={styles} {...attributes}>
+		<!--
+            Components behave differently from elements.
+            However, we'd like to add support for them.
+            For now, we'll just pass the props to the component.
+        -->
+		<svelte:component this={as} class={styles} {...$$props}>
 			<slot />
 		</svelte:component>
 	{/if}

--- a/src/lib/core/attributes.ts
+++ b/src/lib/core/attributes.ts
@@ -1,0 +1,30 @@
+/**
+ * Ideally, we should be able to use the `props` attribute to forward all props to the underlying element.
+ * However, this would be really troublesome to maintain as we would have to manually add all props to the `props` attribute.
+ * Instead, we use the `as` attribute to determine the underlying element and forward all props to it.
+ *
+ * If the `as` attribute is a string, we use the `svelte:element` component to forward all props to the underlying element.
+ * In future versions of Svelte, we can use the `use:props` directive to forward all props to the underlying element.
+ * The `props` attribute may also become deprecated.
+ *
+ * @param as The underlying element
+ * @param props The props to forward
+ */
+export const forwardAttributes = (as: string, props: Record<string, string>) => {
+	let attributes: string[] = [];
+	if (typeof as === 'string') {
+		const element = document.createElement(as);
+		attributes = Object.keys(Object.getPrototypeOf(element));
+	}
+	return (node: Element) => {
+		attributes.forEach((attr) => {
+			if (props[attr]) {
+				node.setAttribute(attr, props[attr]);
+			}
+		});
+		return {
+			// eslint-disable-next-line @typescript-eslint/no-empty-function
+			destroy() {}
+		};
+	};
+};

--- a/src/lib/core/index.ts
+++ b/src/lib/core/index.ts
@@ -1,3 +1,4 @@
 export * from './styled';
 export * from './emotion';
 export * from './events';
+export * from './attributes';


### PR DESCRIPTION
Currently, Chakra UI fails to pass props properly to underlying elements. This means when we have a custom Box such as:

```jsx
<Box as="img" src="https://elcharitas.dev/favicon.png" />
```

In the example above, the `src` prop above would not be passed to the created image.
This PR fixes this