### PR TITLE
chore: cleanup theme provider

### DIFF
--- a/src/lib/components/providers/ChakraProvider.svelte
+++ b/src/lib/components/providers/ChakraProvider.svelte
@@ -1,19 +1,18 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { theme as baseTheme, themeStore } from '$lib/theme';
+	import type { theme as baseTheme } from '$lib/theme';
 	import GlobalStyles from './GlobalStyles.svelte';
 
-	export let theme = baseTheme;
+	export let theme: typeof baseTheme = undefined;
 	export let styles = {};
 
 	let isComponentMounted = false;
-	themeStore.set({ ...baseTheme, ...theme });
 
 	onMount(() => {
 		isComponentMounted = true;
 	});
 </script>
 
-<GlobalStyles {styles} />
+<GlobalStyles {styles} {theme} />
 
 <div style={!isComponentMounted ? 'display: none' : undefined}><slot /></div>

--- a/src/lib/components/providers/GlobalStyles.svelte
+++ b/src/lib/components/providers/GlobalStyles.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { toCSSVar } from '@chakra-ui/styled-system';
-	import { themeStore } from '$lib/theme';
+	import { themeStore, type theme as baseTheme } from '$lib/theme';
 	import { injectGlobal } from '$lib/core';
+	import { onMount } from 'svelte';
 
 	export let styles = {};
+	export let theme: typeof baseTheme;
 
 	injectGlobal({
 		'html, body': {
@@ -12,5 +14,9 @@
 		},
 		':host, :root, [data-theme]': toCSSVar($themeStore).__cssVars,
 		...styles
+	});
+
+	onMount(() => {
+		if (theme) themeStore.set(theme);
 	});
 </script>

--- a/src/lib/components/providers/index.ts
+++ b/src/lib/components/providers/index.ts
@@ -1,4 +1,2 @@
-/** @deprecated */
-export { default as ChakraProvider } from './ThemeProvider.svelte'; // backwards compatibility
-export { default as ThemeProvider } from './ThemeProvider.svelte';
+export { default as ChakraProvider } from './ChakraProvider.svelte';
 export { default as GlobalStyles } from './GlobalStyles.svelte';

--- a/src/lib/index.d.ts
+++ b/src/lib/index.d.ts
@@ -2,16 +2,11 @@ import type { SvelteComponentTyped } from 'svelte';
 import { ChakraComponentProps, PropVariant } from './types';
 
 /**
- * ThemeProvider is the root component that provides theming to all other Chakra components.
- */
-export class ThemeProvider extends SvelteComponentTyped<{ theme: object }> {}
-/**
  * ChakraProvider is the root component that provides context to all other Chakra components.
  * It is the equivalent of `ChakraProvider` in `@chakra-ui/react`.
  * It is required for all Chakra components to work.
- * @deprecated
  */
-export class ChakraProvider extends ThemeProvider {}
+export class ChakraProvider extends SvelteComponentTyped<{ theme: object }> {}
 
 /**
  * Box is a generic component that can be used to render any HTML element.

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import { ThemeProvider, Box, Container } from '$lib/components';
+	import { ChakraProvider, Box, Container } from '$lib/components';
 	import Navbar from '$docs/layout/Navbar.svelte';
 	import { bg, color } from '$docs/stores';
 	import 'highlightjs/styles/atom-one-dark.css';
 </script>
 
-<ThemeProvider>
+<ChakraProvider>
 	<Box
 		bg={$bg}
 		color={$color}
@@ -26,4 +26,4 @@
 			<slot />
 		</Container>
 	</Box>
-</ThemeProvider>
+</ChakraProvider>

--- a/src/routes/docs/pages/installation.md
+++ b/src/routes/docs/pages/installation.md
@@ -1,3 +1,7 @@
+---
+title: Installation
+---
+
 # Installation
 
 To use Chakra UI in your project, run one of the following commands in your terminal:


### PR DESCRIPTION
Personally, I prefer the ThemeProvider API to ChakraProvider.

However, this is just semantics and `ThemeProvider` would seem confusing to users coming from React background.

This PR cleans `ThemeProvider` completely.